### PR TITLE
add basic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-Alien-Web-*
+/Alien-Web-*

--- a/t/alien_web.t
+++ b/t/alien_web.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Spec;
+use lib File::Spec->rel2abs('t/lib');
+
+require_ok 'Alien::Web::Foo';
+
+{
+  my $path = Alien::Web::Foo->path;
+  
+  ok -d $path, "path returns a directory path";
+  note "path is $path";
+  
+  ok -f "$path/example.js", "directory contains example.js";
+};
+
+{
+  my $dir = Alien::Web::Foo->dir;
+  
+  isa_ok $dir, 'Path::Class::Dir';
+  
+  ok -d $dir, "dir returns a directory path";
+  note "dir is $dir";
+  
+  my $file = $dir->file('example.js');
+  
+  ok -f $file, "dir contains example.js";
+  like( $file->slurp, qr{/\* some javasscript perhaps \*/}, 'content of example.js' );
+
+}
+
+done_testing;

--- a/t/lib/Alien/Web/Foo.pm
+++ b/t/lib/Alien/Web/Foo.pm
@@ -1,0 +1,7 @@
+package Alien::Web::Foo;
+
+use strict;
+use warnings;
+use base qw( Alien::Web );
+
+1;

--- a/t/lib/auto/share/dist/Alien-Web-Foo/example.js
+++ b/t/lib/auto/share/dist/Alien-Web-Foo/example.js
@@ -1,0 +1,1 @@
+/* some javasscript perhaps */


### PR DESCRIPTION
Retrying #1 

The problem is that the `.gitignore` was excluding the share directory, and I didn't notice, sorry about that!  By only ignoring Alien-Web in the root this allows the file to be included in the share directory.

`Alien::Web` provides some useful basic functionality for bundling static files as an Alien dist.  This patch adds some basic tests so that it can be used with further confidence.